### PR TITLE
Be more specific than "SHA-2 family"

### DIFF
--- a/bagit.xml
+++ b/bagit.xml
@@ -743,9 +743,9 @@ mapping common algorithm names to normalized names:
 
 </list></t>
         <t>
-  Starting with BagIt 1.0, bag creation and validation tools &must; support the SHA-2 family of
-  algorithms <xref target="RFC6234"/> and &should; enable SHA-512 by default
-  when creating new bags.
+  Starting with BagIt 1.0, bag creation and validation tools &must; support the
+  SHA-256 and SHA-512 algorithms <xref target="RFC6234"/> and &should; enable
+  SHA-512 by default when creating new bags.
 
   For backwards-compatibility implementers &should; support
   MD-5 <xref target="RFC1321"/> and SHA-1 <xref target="RFC3174"/>.


### PR DESCRIPTION
I don't think it makes sense to say "SHA-2 family" in a normative statement about digests that MUST be supported. I think the intention is to mandate support for SHA-256 and SHA-512 (and not SHA-224 or SHA-384). 