### PR TITLE
Avoid confusing "sub-directory must not be changed"

### DIFF
--- a/bagit.xml
+++ b/bagit.xml
@@ -393,7 +393,7 @@ Tag-File-Character-Encoding: UTF-8
             correctness.
             Payload files &may; be organized in arbitrary sub-directory structures
             within the payload directory, however for the purpose of this specification
-            such sub-directory structures and file names have no given meaning.
+            such sub-directory structures and filenames have no given meaning.
           </t>
         </section>
         <!-- /Payload Directory -->

--- a/bagit.xml
+++ b/bagit.xml
@@ -391,8 +391,9 @@ Tag-File-Character-Encoding: UTF-8
             The files under the payload directory are called payload files, or the payload.
             Each payload file is treated as an opaque octet stream when verifying file
             correctness.
-            Any sub-directory structure within the payload &must-not; be changed but is
-            otherwise ignored for purposes relating to this specification.
+            Payload files &may; be organized in arbitrary sub-directory structures
+            within the payload directory, however for the purpose of this specification
+            such sub-directory structures and file names have no given meaning.
           </t>
         </section>
         <!-- /Payload Directory -->


### PR DESCRIPTION
It is out of scope for this specification to specify "changes" to bags
or the process of archiving an existing directory file structure into
bagit.

Rather we should say that the payload files may be in sub-directories
(data/ is not flat), and just that the directory and filenames have no
given meaning .. HERE.

Obviously, just like the octet bytes they have a
meaning to someone.

(If we are going to talk about "change" this opens a can of worms about
changes to checksums, changes to tag files, augmenting bag-info.txt etc
etc)