### PR TITLE
Avoid confusing MAY clause

### DIFF
--- a/bagit.xml
+++ b/bagit.xml
@@ -338,7 +338,7 @@ in arbitrary file hierarchies and &may; have
 any name that is not reserved for a file or directory in this specification.
 </t>
       <t>
-The base directory &may; have any name.
+The base directory can have any name.
 </t>
       <figure>
         <artwork>


### PR DESCRIPTION
Avoids

> The base directory MAY have any name


... as it implies you should only use "any name" if you really know what
you are doing. But really we don't recommend any particular name, so we
can't use MAY here.

From [RFC2119](https://www.ietf.org/rfc/rfc2119.txt):

> 5. MAY   This word, or the adjective "OPTIONAL", mean that an item is
   truly optional.  One vendor may choose to include the item because a
   particular marketplace requires it or because the vendor feels that
   it enhances the product while another vendor may omit the same item.
   An implementation which does not include a particular option MUST be
   prepared to interoperate with another implementation which does
   include the option, though perhaps with reduced functionality. In the
   same vein an implementation which does include a particular option
   MUST be prepared to interoperate with another implementation which
   does not include the option (except, of course, for the feature the
   option provides.)

