### PR TITLE
 Only CR, LF and % are %-escaped 

### DIFF
--- a/bagit.xml
+++ b/bagit.xml
@@ -1140,7 +1140,7 @@ filename              = "data/"
 unreserved            = ALPHA / DIGIT / "-" / "." / "_" / "~"
 sub-delims            = "!" / "$" / "&" / DQUOTE / "'" / "(" / ")" /
                         "*" / "+" / "," / ";" / "=" / "/"              
-pct-encoded           = "%0D" / "%0A" / "%25"
+pct-encoded           = "%0D" / "%0d" / "%0A" / "%0a" / "%25"
 ending                = CR / LF / CRLF
 ]]></artwork>
         </figure>

--- a/bagit.xml
+++ b/bagit.xml
@@ -455,7 +455,8 @@ manifest-sha1.txt
               <t>
                 If a <spanx style="emph">filename</spanx> includes a newline
                 (LF), a carriage return (CR),
-                or carriage return plus newline (CRLF) it &must; be
+                carriage return plus newline (CRLF) or
+                percent (%), those characters (and only those) &must; be
                 percent-encoded following <xref target="RFC3986"/>.
               </t>
             </list>
@@ -1139,7 +1140,7 @@ filename              = "data/"
 unreserved            = ALPHA / DIGIT / "-" / "." / "_" / "~"
 sub-delims            = "!" / "$" / "&" / DQUOTE / "'" / "(" / ")" /
                         "*" / "+" / "," / ";" / "=" / "/"              
-pct-encoded           = "%" HEXDIG HEXDIG
+pct-encoded           = "%0D" / "%0A" / "%25"
 ending                = CR / LF / CRLF
 ]]></artwork>
         </figure>

--- a/bagit.xml
+++ b/bagit.xml
@@ -666,7 +666,13 @@ Internal-Sender-Description: Uncompressed greyscale TIFFs created
             <spanx style="emph">filename</spanx>. One or more linear whitespace
             characters (spaces or tabs) &must; separate these
             three values, and any such characters in the <spanx style="emph">url</spanx>
-            &must; be percent-encoded <xref target="RFC3986"/>.  There is no
+            &must; be percent-encoded <xref target="RFC3986"/>.  
+            If <spanx style="emph">filename</spanx> includes a line feed
+            (LF), a carriage return (CR),
+            carriage return plus line feed (CRLF) or
+            percent sign (%), those characters (and only those) &must; be
+            percent-encoded following <xref target="RFC3986"/>.
+            There is no
             limitation on the length of any of the fields in the fetch file.
           </t>
 

--- a/bagit.xml
+++ b/bagit.xml
@@ -453,10 +453,10 @@ manifest-sha1.txt
               <t>There is no limitation on the length of a pathname.</t>
               <t>The payload manifest &must-not; reference files outside the payload directory.</t>
               <t>
-                If a <spanx style="emph">filename</spanx> includes a newline
+                If a <spanx style="emph">filename</spanx> includes a line feed
                 (LF), a carriage return (CR),
-                carriage return plus newline (CRLF) or
-                percent (%), those characters (and only those) &must; be
+                carriage return plus line feed (CRLF) or
+                percent sign (%), those characters (and only those) &must; be
                 percent-encoded following <xref target="RFC3986"/>.
               </t>
             </list>


### PR DESCRIPTION
# tl;dr

Only do RFC3986-style `%`-escaping of CR, LF and (new) `%`.

# Discussion point

In the current text there is a discrepancy, the ABNF proposes only a limited set of sub-delims, e.g. `#`  `^` or `æ` are not allowed, with `pct-encoding` suggesting a generic RFC3986 URI byte encoding (presumably in UTF8?). 

However the current spec only seems to permit %-encoding if there is a CR/LF in the filepath is, in which case the whole filepath is escaped. I get the feeling the intention was that only those particular characters were to be %-encoded.

We either need to allow escaping of any characters (in which case `%` must always be escaped, so consumers can know if a filepath string is escaped or not), or only have a limited search-replace escaping of particular control characters - which for some reason is limited to just CR LF (what about `\t` ?).

But even in the second case (which this PR is suggesting), a filename that on disk is called `fred%0a.txt` would be impossible to capture in bagit as in the manifest it would be indistinguishable from a filename `fred\n.txt` -- and so also here the `%` should be escaped as `%25`.

I believe we want to stay closer to the `md5sum` output (as referenced in the spec) than the more general URI format, so say ` ` should not be escaped to `%20` - although that would be a more predictable URI-style escaping that actually follows RFC3986.

Also I don't think we want to suggest that all non-ASCII characters should be `%`-encoded, which is what RFC3986 would say - rather they should be represented directly in the declared `Tag-File-Character-Encoding`.