### PR TITLE
Avoid unknown Source-URL in example

### DIFF
--- a/bagit.xml
+++ b/bagit.xml
@@ -844,7 +844,8 @@ highsmith-tahoe/
 |    (Tag-File-Character-Encoding: UTF-8                           )
 |
 |   bag-info.txt
-|    (Source-URL: https://www.loc.gov/resource/highsm.23364/       )
+|    (Internal-Sender-Description: Download link found at          )
+|    (  https://www.loc.gov/resource/highsm.23364/                 )
  </artwork>
         </figure>
       </section>


### PR DESCRIPTION
The key `Source-URL` is not defined anywhere else. It's confusing to use it in this example, even if "other arbitrary metadata  elements MAY also be present."

If we want to show "custom" keys then that should be a different example - we should not violate our own MAY in an unrelated example.