### PR TITLE
tag manifests should be complete

### DIFF
--- a/bagit.xml
+++ b/bagit.xml
@@ -480,8 +480,9 @@ placeholder file with a name such as ".keep".
             A bag &may; contain one or more tag manifests, in which case each tag manifest &must; list the same set of tag files.
           </t>
           <t>
-            Each tag manifest &must; list every payload manifest, but &must-not; list any tag manifests.
-            Each tag manifest &should; list the remaining tag files present in the bag.
+            Each tag manifest &must; list every payload manifest.
+            Each tag manifest &must-not; list any tag manifests,
+            but &should; list the remaining tag files present in the bag.
           </t>
           <t>
             A tag manifest file &must; have a name of the form

--- a/bagit.xml
+++ b/bagit.xml
@@ -477,10 +477,11 @@ placeholder file with a name such as ".keep".
             checksum algorithm.
           </t>
           <t>
-            A bag &may; contain one or more tag manifests.
+            A bag &may; contain one or more tag manifests, in which case each tag manifest &must; list the same set of tag files.
           </t>
           <t>
-            Each tag manifest &must; list every payload manifest.
+            Each tag manifest &must; list every payload manifest, but &must-not; list any tag manifests.
+            Each tag manifest &should; list the remaining tag files present in the bag.
           </t>
           <t>
             A tag manifest file &must; have a name of the form


### PR DESCRIPTION
.. and can't list tag manifests for obvious reasons.

If you agree we can change the &should; to a &must; to make it consistent with payload manifests. Then we might need a BagIt 1.0 clause here as well; as well as clarifying if `bagit.txt` is included or not.