### PR TITLE
About multiplicity of metadata elements

### DIFF
--- a/bagit.xml
+++ b/bagit.xml
@@ -600,8 +600,8 @@ As a result, no <spanx style="emph">filename</spanx> listed in a tag manifest be
               ordinal number within the group; if T is not known, specify it as "?"
               (question mark).  Examples:  1 of 2, 4 of 4, 3 of ?, 89 of 145.
               This metadata element &should-not; be repeated.
-              If this metadata element is present, the Bag-Group-Identifier element
-              &should; be present.              
+              If this metadata element is present, it is &recommended; to also
+              include the Bag-Group-Identifier element.
           </t>
           <t hangText="Internal-Sender-Identifier">
               An alternate sender-specific identifier for the content

--- a/bagit.xml
+++ b/bagit.xml
@@ -534,7 +534,8 @@ As a result, no <spanx style="emph">filename</spanx> listed in a tag manifest be
           <t>
             The following are reserved metadata elements. The use of these reserved
             metadata elements are &optional; but encouraged. Reserved metadata
-            element names are case-insensitive.
+            element names are case-insensitive. Except where indicated otherwise, 
+            these metadata element names &may; be repeated to capture multiple values.
           </t>
 
           <t>
@@ -560,6 +561,7 @@ As a result, no <spanx style="emph">filename</spanx> listed in a tag manifest be
           </t>
           <t hangText="Bagging-Date">
               Date (YYYY-MM-DD) that the content was prepared for delivery.
+              This metadata element &should-not; be repeated.
           </t>
           <t hangText="External-Identifier">
               A sender-supplied identifier for the bag.
@@ -569,6 +571,7 @@ As a result, no <spanx style="emph">filename</spanx> listed in a tag manifest be
               by an abbreviation such as MB (megabytes), GB, or TB; for example,
               42600 MB, 42.6 GB, or .043 TB.  Compared to Payload-Oxum (described
               next), Bag-Size is intended for human consumption.
+              This metadata element &should-not; be repeated.
           </t>
           <t hangText="Payload-Oxum">
               The "octetstream sum" of the payload, intended for the
@@ -581,6 +584,7 @@ As a result, no <spanx style="emph">filename</spanx> listed in a tag manifest be
               octets (8-bit bytes) across all payload file content and
               <spanx style="emph">StreamCount</spanx> is the total number of
               payload files.
+              This metadata element &must-not; be repeated.
           </t>
           <t hangText="Bag-Group-Identifier">
               A sender-supplied identifier for the set, if any, of bags
@@ -588,12 +592,16 @@ As a result, no <spanx style="emph">filename</spanx> listed in a tag manifest be
               This identifier must be unique across the sender's content, and if
               recognizable as belonging to a globally unique scheme, the receiver
               should make an effort to honor reference to it.
+              This metadata element &should-not; be repeated.
           </t>
           <t hangText="Bag-Count">
               Two numbers separated by "of", in particular, "N of T",
               where T is the total number of bags in a group of bags and N is the
               ordinal number within the group; if T is not known, specify it as "?"
               (question mark).  Examples:  1 of 2, 4 of 4, 3 of ?, 89 of 145.
+              This metadata element &should-not; be repeated.
+              If this metadata element is present, the Bag-Group-Identifier element
+              &should; be present.              
           </t>
           <t hangText="Internal-Sender-Identifier">
               An alternate sender-specific identifier for the content


### PR DESCRIPTION
Some of these don't make sense to repeat, but except for Payload-Oxum there is probably no need to be strict. And for third-party elements then it's up to them if repeating is allowed, e.g. as [BagIt-Profile-Identifier](https://github.com/bagit-profiles/bagit-profiles)

`Payload-Oxum` must not be repeated as it  has been stated in this spec to be used for quick validation.