### PR TITLE
RECOMMENDED that last line in tag files ends with linefeed

### DIFF
--- a/bagit.xml
+++ b/bagit.xml
@@ -702,7 +702,7 @@ Internal-Sender-Description: Uncompressed greyscale TIFFs created
           the text tag file format described below.
         </t>
         <t>
-          Text tag files are line-oriented, and each line &must; be terminated
+          Text tag files are line-oriented, and each line (including the last) &must; be terminated
           by a newline (LF), a carriage return (CR), or carriage return plus
           newline (CRLF). Text tag file names &must; end in the extension
           ".txt".
@@ -1118,7 +1118,7 @@ definitions use the core rules (e.g. DIGIT, HEXDIG, etc) as defined in
                 <preamble>bagit.txt ABNF:</preamble>
                 <artwork type="abnf" xml:space="preserve"><![CDATA[
 bagit-txt = "BagIt-Version: " 1*DIGIT "." 1*DIGIT ending
-            "Tag-File-Character-Encoding: " encoding
+            "Tag-File-Character-Encoding: " encoding ending
 encoding  = 1*CHAR
 ending    = CR / LF / CRLF
     ]]></artwork>

--- a/bagit.xml
+++ b/bagit.xml
@@ -702,9 +702,11 @@ Internal-Sender-Description: Uncompressed greyscale TIFFs created
           the text tag file format described below.
         </t>
         <t>
-          Text tag files are line-oriented, and each line (including the last) &must; be terminated
+          Text tag files are line-oriented, and each line &must; be terminated
           by a newline (LF), a carriage return (CR), or carriage return plus
-          newline (CRLF). Text tag file names &must; end in the extension
+	  newline (CRLF). It is &recommended; that the last line in a tag
+	  file also ends with LF, CR or CRLF.
+	  Text tag file names &must; end in the extension
           ".txt".
         </t>
         <t>


### PR DESCRIPTION
.. as pointed out in the ABNF patch, even the second line in `bagit.txt` must end with linefeed.