### PR TITLE
RFC6920 registry for hash algorithm names

### DIFF
--- a/bagit.xml
+++ b/bagit.xml
@@ -734,7 +734,7 @@ of a checksum are outside the scope of this document.
 <t>
 To avoid future ambiguity, the checksum algorithm &should; be registered
 in IANA's "Named Information Hash Algorithm Registry" <xref target="ni-registry" />
-according to <xref target="RFC6920"/>, but MAY for backwards compatibility also be the
+according to <xref target="RFC6920"/>, but &may; for backwards compatibility also be the
 MD5 <xref target="RFC1321"/> or SHA-1 <xref target="RFC3174"/>.
 </t>
         <t>

--- a/bagit.xml
+++ b/bagit.xml
@@ -734,7 +734,7 @@ of a checksum are outside the scope of this document.
 <t>
 To avoid future ambiguity, the checksum algorithm &should; be registered
 in IANA's "Named Information Hash Algorithm Registry" <xref target="ni-registry" />
-according to <xref target="RFC6920"/>, but MAY for backwards-compatibility also be the
+according to <xref target="RFC6920"/>, but MAY for backwards compatibility also be the
 MD5 <xref target="RFC1321"/> or SHA-1 <xref target="RFC3174"/>.
 </t>
         <t>
@@ -753,7 +753,7 @@ mapping common algorithm names to normalized names:
   SHA-256 and SHA-512 algorithms <xref target="RFC6234"/> and &should; enable
   SHA-512 by default when creating new bags.
 
-  For backwards-compatibility implementers &should; support
+  For backwards compatibility implementers &should; support
   MD5 <xref target="RFC1321"/> and SHA-1 <xref target="RFC3174"/>.
 
   Implementers are encouraged to simplify the process of adding additional

--- a/bagit.xml
+++ b/bagit.xml
@@ -15,6 +15,7 @@
 <!ENTITY RFC3986 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.3986.xml">
 <!ENTITY RFC5226 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.5226.xml">
 <!ENTITY RFC6234 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6234.xml">
+<!ENTITY RFC6920 SYSTEM "http://xml.resource.org/public/rfc/bibxml/reference.RFC.6920.xml">
 <!-- RFC 2119 entities - for convenience --><!ENTITY must "MUST">
 <!ENTITY must-not "MUST NOT">
 <!ENTITY required "REQUIRED">
@@ -730,17 +731,22 @@ Checksum values &must; be encoded so as to conform to the manifest format
 specified in <xref target="sec-payload-manifest"/>. However, the internal details
 of a checksum are outside the scope of this document.
 </t>
+<t>
+To avoid future ambiguity, the checksum algorithm &should; be registered
+in IANA's "Named Information Hash Algorithm Registry" <xref target="ni-registry" />
+according to <xref target="RFC6920"/>, but MAY for backwards-compatibility also be the
+MD5 <xref target="RFC1321"/> or SHA-1 <xref target="RFC3174"/>.
+</t>
         <t>
-The name of the checksum algorithm &must; be normalized for use in the
-manifest's filename by lowercasing the common name of the algorithm and
+The name of the checksum algorithm &must; be normalized
+for use in the manifest's filename by lowercasing the common name of the algorithm and
 removing all non-alphanumeric characters. Following is a partial list
 mapping common algorithm names to normalized names:
           <list style="symbols">
-            <t>MD-5: md5</t>
+            <t>MD5: md5</t>
             <t>SHA-1: sha1</t>
-            <t>SHA-256: sha256</t>
-            <t>SHA-512: sha512</t>
-
+            <t>sha-256: sha256</t>
+            <t>sha-512: sha512</t>
 </list></t>
         <t>
   Starting with BagIt 1.0, bag creation and validation tools &must; support the
@@ -748,7 +754,7 @@ mapping common algorithm names to normalized names:
   SHA-512 by default when creating new bags.
 
   For backwards-compatibility implementers &should; support
-  MD-5 <xref target="RFC1321"/> and SHA-1 <xref target="RFC3174"/>.
+  MD5 <xref target="RFC1321"/> and SHA-1 <xref target="RFC3174"/>.
 
   Implementers are encouraged to simplify the process of adding additional
   manifests using new algorithms to streamline the process of in-place
@@ -1219,6 +1225,15 @@ This draft does not request any action from IANA.
       &RFC3629; <!-- utf-8 -->
       &RFC3986; <!-- URLs -->
       &RFC2234; <!-- ABNF -->
+      &RFC6920; <!-- Named Information Hash Algorithm Registry -->
+
+      <reference anchor="ni-registry" target="https://www.iana.org/assignments/named-information/named-information.xhtml">
+        <front>
+          <title>Named Information Hash Algorithm Registry</title>
+          <author><organization>IANA</organization></author>
+          <date year="2016" month="9" day="14"/>
+        </front>
+      </reference>
 
       <reference anchor="UNICODE-TR15" target="http://www.unicode.org/reports/tr15/">
         <front>

--- a/bagit.xml
+++ b/bagit.xml
@@ -738,8 +738,8 @@ according to <xref target="RFC6920"/>, but &may; for backwards compatibility als
 MD5 <xref target="RFC1321"/> or SHA-1 <xref target="RFC3174"/>.
 </t>
         <t>
-The name of the checksum algorithm &must; be normalized
-for use in the manifest's filename by lowercasing the common name of the algorithm and
+The name of the checksum algorithm &must; be normalized for use in the
+manifest's filename by lowercasing the common name of the algorithm and
 removing all non-alphanumeric characters. Following is a partial list
 mapping common algorithm names to normalized names:
           <list style="symbols">


### PR DESCRIPTION
Reference [Named Information Hash Algorithm Registry](https://www.iana.org/assignments/named-information/named-information.xhtml) for future algorithm names. 

I added explicitly MD5/SHA1 legacy algorithms as permitted, as unlike `sha-256` and `sha-512` these are not in the registry.

Left as an exercise to the reader is how to normalise `sha3-512`.



