### PR TITLE
Tag and payload manifests

### DIFF
--- a/bagit.xml
+++ b/bagit.xml
@@ -494,6 +494,9 @@ placeholder file with a name such as ".keep".
             the format described in <xref target="bag-checksum-algorithms"/>
             specifying the bag checksum algorithm used in that manifest.
           </t>
+          <t>
+            Tag manifests &should; use the same algorithms as for the payload manifests in the bag.
+          </t>
           <figure>
             <preamble>Example tag manifest filenames:</preamble>
             <artwork>

--- a/bagit.xml
+++ b/bagit.xml
@@ -1209,10 +1209,11 @@ ending     = CR / LF / CRLF
     <section title="Acknowledgements">
       <t>
 BagIt owes much to many thoughtful contributors and reviewers, including
-Stephen Abrams, Mike Ashenfelder, Dan Chudnov, Dave Crocker, Brad Hards, Scott Fisher, Keith
-Johnson, Erik Hetzner, Leslie Johnston, David Loy, Mark Phillips, Tracy Seneca,
-Brian Tingle, Adam Turoff, Jim Tuttle, and Stian Soiland-Reyes.
-</t>
+Stephen Abrams, Mike Ashenfelder, Dan Chudnov, Dave Crocker, Scott Fisher, 
+Brad Hards, Erik Hetzner, Keith Johnson, Leslie Johnston, Nick Krabbenhoeft,
+David Loy, Mark Phillips, Tracy Seneca, Stian Soiland-Reyes, Brian Tingle, 
+Adam Turoff and Jim Tuttle.
+      </t>
       <section title="IANA Considerations">
         <t>
 This draft does not request any action from IANA.


### PR DESCRIPTION
> Tag manifests SHOULD use the same algorithms as for the payload manifests in the bag.

This fixes #25, concurred by @johnscancella and @nkrabben.
